### PR TITLE
Enable mingw cross-compilation using wclang

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,22 @@ that's it.
 If the build system is unable to find your GMP installation, please edit the paths in file makeConstants.  In general, the project uses a basic makefile.  In the event that you have to do something more complicated to get the library to compile, or if you are unable to get it to compile, please e-mail me or open an issue on GitHub.  Doing so is much more effective than cursing at your computer, and will save other users trouble in the future.
 
 
-Windows
+Windows Native
 ----
 
 Cork uses C++11, so you will need the most recent compiler; Visual Studio 2012 or higher please.  You will also need to install the MPIR arithmetic library into your Visual Studio environment.
 
 Once this is done, you can use the solution and project files in the /win/ subdirectory to build the demo program.  The solution/project is not currently configured to build a DLL.  Please bug me if this is an issue for you.
 
+
+Cross-Compiling on Unix for Windows
+-----------------------------------
+
+Cork can be cross compiled for windows using [mingw-w64](http://mingw-w64.sourceforge.net) and [wclang](https://github.com/tpoechtrager/wclang) which is a clang frontend for mingw. You first need to cross compile the GMP library using mingw-w64 and then:
+
+    make CC=w32-clang CXX=w32-clang++ GMP_INC_DIR=/usr/i686-w64-mingw32/include/ GMP_LIB_DIR=/usr/i686-w64-mingw32/lib/
+
+Tune the `GMP_INC_DIR` and `GMP_LIB_DIR` variables according to where gmp was compiled. It should build a Windows executable under `bin/cork`. You can rename it `cork.exe` and you are set.
 
 Licensing
 =========

--- a/src/isct/fixint.h
+++ b/src/isct/fixint.h
@@ -45,7 +45,7 @@
 
 
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <mpir.h>
 #else
 #include <gmp.h>

--- a/src/isct/gmpext4.h
+++ b/src/isct/gmpext4.h
@@ -25,7 +25,7 @@
 // +-------------------------------------------------------------------------
 #pragma once
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #pragma warning(disable: 4800)
 #pragma warning(disable: 4244)
 #include <mpirxx.h>

--- a/src/mesh/mesh.isct.tpp
+++ b/src/mesh/mesh.isct.tpp
@@ -632,7 +632,7 @@ public:
         quantized_coords.resize(N);
         uint write = 0;
         TopoCache::verts.for_each([&](Vptr v) {
-#ifdef _WIN32
+#ifdef _MSC_VER
             Vec3d raw = mesh->verts[v->ref].pos;
 #else
             Vec3d raw = TopoCache::mesh->verts[v->ref].pos;

--- a/src/mesh/mesh.tpp
+++ b/src/mesh/mesh.tpp
@@ -250,7 +250,7 @@ typename Mesh<VertData,TriData>::NeighborCache
 }
 
 // This function signature is an amazing disaster...
-#ifdef _WIN32
+#ifdef _MSC_VER
 template<class VertData, class TriData>
 template<class Edata>
 typename Mesh<VertData,TriData>::EGraphCache<Edata>

--- a/src/util/prelude.h
+++ b/src/util/prelude.h
@@ -31,6 +31,10 @@
 #include <algorithm>
 #include <iostream>
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 #ifndef uint
 typedef unsigned int uint;
 #endif


### PR DESCRIPTION
Hi,

I cross-compiled cork for Windows on Arch-Linux. I had to update a few things, mostly ifdefs. I also updated the README to show how to do it.
