### PR TITLE
update gmp brew paths / versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ GMPLD     := -L$(GMP_LIB_DIR) -lgmpxx -lgmp
 LINK         := $(CXXFLAGS) $(GMPLD)
 LINKD        := $(CXXDFLAGS) $(GMPLD)
 ifeq ($(PLATFORM),Darwin)
-  LINK  := $(LINK) -Wl,-no_pie
-  LINKD := $(LINK) -Wl,-no_pie
+  LINK  := $(LINK) -Wl
+  LINKD := $(LINK) -Wl
 endif
 
 
@@ -85,12 +85,12 @@ endif
 # ***********************-----------------+
 # | SRCS defines a generic bag of sources |
 # +---------------------------------------+
-MATH_SRCS    := 
+MATH_SRCS    :=
 UTIL_SRCS    := timer log
 ISCT_SRCS    := empty3d quantization
-MESH_SRCS    := 
-RAWMESH_SRCS := 
-ACCEL_SRCS   := 
+MESH_SRCS    :=
+RAWMESH_SRCS :=
+ACCEL_SRCS   :=
 FILE_SRCS    := files ifs off
 SRCS         := \
     cork \

--- a/makeConstants
+++ b/makeConstants
@@ -1,3 +1,3 @@
 
-GMP_INC_DIR = /usr/local/Cellar/gmp/5.0.2/include
-GMP_LIB_DIR = /usr/local/Cellar/gmp/5.0.2/lib
+GMP_INC_DIR = /opt/homebrew/Cellar/gmp/6.3.0/include
+GMP_LIB_DIR = /opt/homebrew/Cellar/gmp/6.3.0/lib


### PR DESCRIPTION
and remove no-pie
```
ld: warning: -no_pie is deprecated when targeting new OS versions
ld: warning: -no_pie ignored for arm64*
```